### PR TITLE
go: upgrade to Go 1.26 and modernize

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/nicksnyder/renovate-dependency-test
 
-go 1.14
+go 1.26.4
 
 require github.com/pkg/errors v0.7.0


### PR DESCRIPTION
Upgrades this repository to the latest Go 1.26 release (go1.26.4) across its build,
CI, and release configuration, then runs `go fix ./...` twice (Go 1.26's analyzer-based
modernizers) to apply safe, automatic modernizations enabled by the new language version.

Generated this change with a Sourcegraph batch change.

[_Created by Sourcegraph agentic batch change._](https://sourcegraph.sourcegraph.com/batch-change-agents/172)